### PR TITLE
Add all sorts of receipts

### DIFF
--- a/src/components/ErrorReceipt.js
+++ b/src/components/ErrorReceipt.js
@@ -1,0 +1,40 @@
+// @format
+import React, { Component } from "react";
+import { Flex, Box } from "rimble-ui";
+
+export default class ErrorReceipt extends Component {
+  render() {
+    const {
+      receipt: { message }
+    } = this.props;
+
+    return (
+      <div>
+        <h3
+          style={{
+            textAlign: "center",
+            fontWeight: "bold",
+            marginBottom: "1em"
+          }}
+        >
+          ❌ Err0r! 😭
+        </h3>
+        <Flex alignItems="center" justifyContent="space-between">
+          <Box style={{ textAlign: "center" }} width={1}>
+            {/* Yeah this is not rimble-ui but I really had no time... */}
+            <i
+              className="fas fa-times-circle"
+              style={{
+                color: "rgb(233, 23, 23)",
+                fontSize: 180,
+                opacity: 0.7,
+                marginBottom: "10px"
+              }}
+            />
+            <h5>{message}</h5>
+          </Box>
+        </Flex>
+      </div>
+    );
+  }
+}

--- a/src/components/Receipt.js
+++ b/src/components/Receipt.js
@@ -3,6 +3,7 @@ import React, { Component } from "react";
 import TxReceipt from "./TxReceipt";
 import TradeReceipt from "./TradeReceipt";
 import PassportReceipt from "./PassportReceipt";
+import ErrorReceipt from "./ErrorReceipt";
 
 export default class Receipt extends Component {
   render() {
@@ -13,10 +14,7 @@ export default class Receipt extends Component {
     if (type === "trade") {
       return <TradeReceipt {...this.props} />;
     } else if (type === "error") {
-      // TODO: Display funny error
-      // NOTE: Alberto told me that Earth can run out of Goellars or CO2 so
-      // we should annoy the shit out of him when an error occurs
-      console.log("display an error");
+      return <ErrorReceipt {...this.props} />;
     } else if (type === "plant") {
       // TODO: Implement tree receipt
       console.log("display a plant");

--- a/src/components/SendToAddress.js
+++ b/src/components/SendToAddress.js
@@ -218,7 +218,7 @@ export default class SendToAddress extends React.Component {
           } else {
             this.props.goBack();
             window.history.pushState({},"", "/");
-            let receiptObj = {to:toAddress,from:err.request.account,amount:parseFloat(amount),message:err.error.message,result:err}
+            let receiptObj = {to:toAddress,from:err.request.account,amount:parseFloat(amount),message:err.error.message,type:"error",result:err}
 
             if(this.state.params){
               receiptObj.params = this.state.params

--- a/src/components/TradeReceipt.js
+++ b/src/components/TradeReceipt.js
@@ -138,7 +138,7 @@ export default class TradeReceipt extends Component {
 
   render() {
     const {
-      receipt: { from, to, profit, emission }
+      receipt: { myAddress, theirAddress, myGoellars, myCO2 }
     } = this.props;
     const {
       orientation,
@@ -155,7 +155,7 @@ export default class TradeReceipt extends Component {
         </h3>
         <Flex alignItems="center" justifyContent="space-between">
           <Box style={{ textAlign: "center" }} width={1 / 5}>
-            <Blockie address={from} config={{ size: blockieSize }} />
+            <Blockie address={myAddress} config={{ size: blockieSize }} />
             {/* EXXXTREME 90ies CSS skills incoming */}
             <br />
             You
@@ -168,7 +168,7 @@ export default class TradeReceipt extends Component {
                 size={ranNum(10)}
                 rotate={rotate}
               >
-                + ₲{profit}
+                + ₲{myGoellars}
               </Gain>
               <Gain
                 left={positions.emission.left}
@@ -176,13 +176,13 @@ export default class TradeReceipt extends Component {
                 size={ranNum(10)}
                 rotate={!rotate}
               >
-                + {emission}
+                + {myCO2}
                 Gt CO2
               </Gain>
             </Hero>
           </Box>
           <Box style={{ textAlign: "center" }} width={1 / 5}>
-            <Blockie address={to} config={{ size: blockieSize }} />
+            <Blockie address={theirAddress} config={{ size: blockieSize }} />
             {/* EXXXTREME 90ies CSS skills incoming */}
             <br />
             Your <img style={{ width: "2vw" }} src={newtag} /> buddy
@@ -192,18 +192,12 @@ export default class TradeReceipt extends Component {
           <Confetti active={explosion} config={config} />
         </Flex>
         <Sound
-          // url={profit > emission ? kaching : pollution}
-          // NOTE: We want to fuck with the brain of the players lol
-          url={kaching}
+          url={myGoellars > myCO2 ? kaching : pollution}
           playStatus={soundStatus}
           onFinishedPlaying={() =>
             this.setState({ soundStatus: Sound.status.STOPPED })
           }
         />
-        <p>
-          Animation is currently not optimized for FPS value but instead just
-          tries to render as fast as possible. Pls donate DAI to improve this!
-        </p>
         <p>
           <a href="https://gitcoin.co/grants/127/planet-a" target="_blank">
             To send us some money, click here!

--- a/src/planeta/FinalizeHandshake.js
+++ b/src/planeta/FinalizeHandshake.js
@@ -37,17 +37,6 @@ export default class FinalizeHandshake extends React.Component {
       setReceipt({ type: "error" });
       return;
     }
-
-    setReceipt(
-      // NOTE: Receipt needs to be of type "trade" for correct receipt to be
-      // displayed. "profit" and "emission" needs to be included.
-      Object.assign(finalReceipt, {
-        type: "trade",
-        profit: 0.2,
-        emission: 8
-      })
-    );
-    changeView("receipt");
   }
 
   componentDidMount() {

--- a/src/planeta/TransferPassport.js
+++ b/src/planeta/TransferPassport.js
@@ -93,6 +93,12 @@ export default class TransferPassport extends Component {
     }
   };
 
+  updateState = async (key, value) => {
+    this.setState({ [key]: value }, () => {
+      this.setState({ canSend: this.canSend() });
+    });
+  };
+
   render() {
     const { passports, account } = this.props;
     const { toAddress, canSend } = this.state;

--- a/src/planeta/transactionHandler.js
+++ b/src/planeta/transactionHandler.js
@@ -75,6 +75,7 @@ function parseHandshake(myAddress, inputs, outputs) {
     myAddress,
     myDefect: isDefect(myAddress, myDataBefore, myDataAfter),
     myGoellars: getGoellars(myAddress),
+    myCO2: getCO2(myDataBefore, myDataAfter),
     myPassport,
     theirAddress,
     theirCO2: getCO2(theirDataBefore, theirDataAfter),


### PR DESCRIPTION
## Documentation

It's very simple my dude. The property `type` on a receipt determines which receipt view is shown to the user. There's three `type`s.

### `type === error`=> Something went wrong
```
const receipt = {
  type: "error",
  message: "An error occurred"
}
this.setReceipt(receipt);
this.changeView("receipt");
```

Note that we broke compatibility with the old way of displaying receipts!

<img width="768" alt="Screen Shot 2019-08-16 at 18 30 27" src="https://user-images.githubusercontent.com/2758453/63182904-f367de80-c053-11e9-90c2-01d16ae6ef36.png">


### no `type` in the receipt object => It's a normal Ethereum value transaction (ETH, ERC20, ERC721)

Austin then always passes these parameters:

```
let receiptObj = {
  to:toAddress,
  from:result.from,
  amount:parseFloat(amount),
  message:this.state.message,
  result:result
}
this.setReceipt(receiptObj);
this.changeView("receipt");
```

I'm not totally familiar with what is absolutely required. Hence I recommend looking at components like SendToAddress.js to find out.

### `type === "trade"` => It's a Planet A "trade" transaction

```
const testReceipt = {
  to: "0x901442E4dEeC484E9B2EFDb2bA20FCb19880D9A3",
  from: "0x51Ff1fab76079d20418d1c74DA65653FfE3fD0aa",
  type: "trade",
  profit: 20, // in USD/USG
  emission: 25 // in tons of CO2
}
this.setReceipt(testReceipt);
this.changeView("receipt");
```

### `type === "lock"` => It's a Planet A "plant a tree" transaction

[TODO]