### PR TITLE
Correct comma conversion in inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16296,6 +16296,11 @@
         }
       }
     },
+    "numeral": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
+      "integrity": "sha1-StCAk21EPCVhrtnyGX7//iX05QY="
+    },
     "nwmatcher": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
@@ -16792,6 +16797,11 @@
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "parse-decimal-number": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-decimal-number/-/parse-decimal-number-1.0.0.tgz",
+      "integrity": "sha1-+dSDma6Y8geTX9E9y7yHZU2GWi8="
     },
     "parse-glob": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "identity-obj-proxy": "3.0.0",
     "jsbi-utils": "^1.0.0",
     "leap-core": "^0.32.4",
+    "numeral": "^2.0.6",
+    "parse-decimal-number": "^1.0.0",
     "qrcode-reader": "^1.0.4",
     "qrcode.react": "^0.8.0",
     "query-string": "^6.3.0",

--- a/src/components/SendByScan.js
+++ b/src/components/SendByScan.js
@@ -119,10 +119,10 @@ class SendByScan extends Component {
           this.props.returnToState(returnState, this.props.returnState.goBackView)
         // NOTE: We only need the address and the amount as absolutely necessary
         // parts of the QR code scan. `message` is optional.
-        } else if(Web3.utils.isAddress(dataSplit[0]) && !isNaN(parseFloat(dataSplit[1], 10))) {
+        } else if(Web3.utils.isAddress(dataSplit[0]) && !isNaN(parseFloat(dataSplit[1]))) {
           const returnState = {
             toAddress: dataSplit[0],
-            amount: parseFloat(dataSplit[1], 10)
+            amount: parseFloat(dataSplit[1])
           }
           if (dataSplit.length > 1) {
             returnState.message = decodeURI(dataSplit[2])

--- a/src/components/SendToAddress.js
+++ b/src/components/SendToAddress.js
@@ -168,8 +168,10 @@ export default class SendToAddress extends React.Component {
 
       if(parseFloat(this.props.balance) <= 0){
         this.props.changeAlert({type: 'warning', message: "No Funds."})
-      }else if(parseFloat(this.props.balance)<parseFloat(amount)){
-        // this.props.changeAlert({type: 'warning', message: 'Not enough funds: '+currencyDisplay(Math.floor((parseFloat())*100)/100)})
+          // NOTE: We don't i18nParseFloat here as we already expect it to be
+          // a float when it's set as state and converted by the convertCurrency
+          // method
+      }else if(parseFloat(this.props.balance) < parseFloat(amount)){
         this.props.changeAlert({type: 'warning', message: `Not enough funds: ${this.props.balance}`})
       }else{
         console.log("SWITCH TO LOADER VIEW...",amount)
@@ -201,7 +203,7 @@ export default class SendToAddress extends React.Component {
             //   message: 'Sent! '+result.transactionHash,
             // });
 
-            let receiptObj = {to:toAddress,from:result.from,amount:parseFloat(amount),message:this.state.message,result:result}
+            let receiptObj = {to:toAddress,from:result.from,amount,message:this.state.message,result:result}
 
             if(this.state.params){
               receiptObj.params = this.state.params
@@ -218,7 +220,10 @@ export default class SendToAddress extends React.Component {
           } else {
             this.props.goBack();
             window.history.pushState({},"", "/");
-            let receiptObj = {to:toAddress,from:err.request.account,amount:parseFloat(amount),message:err.error.message,type:"error",result:err}
+            // NOTE: We don't i18nParseFloat here as we already expect it to be
+            // a float when it's set as state and converted by the convertCurrency
+            // method
+            let receiptObj = {to:toAddress,from:err.request.account,amount,message:err.error.message,result:err}
 
             if(this.state.params){
               receiptObj.params = this.state.params
@@ -269,7 +274,7 @@ export default class SendToAddress extends React.Component {
         width={1}
         type="number"
         placeholder={0}
-        step={0.1}
+        step="any"
         value={this.state.amount}
         ref={(input) => { this.amountInput = input; }}
         onChange={event => this.updateState('amount', event.target.value)}
@@ -280,6 +285,7 @@ export default class SendToAddress extends React.Component {
         <Input
           width={1}
           type="number"
+          step="any"
           readOnly
           placeholder={this.props.currencyDisplay(0)}
           value={this.state.amount}

--- a/src/components/WithdrawFromPrivate.js
+++ b/src/components/WithdrawFromPrivate.js
@@ -11,6 +11,7 @@ import {
   Text,
 } from 'rimble-ui'
 import { PrimaryButton } from "./Buttons";
+import i18nParseFloat from "../i18n/parseFloat";
 
 
 // TODO: Can this be state of SendToAddress?
@@ -66,7 +67,7 @@ export default class SendToAddress extends React.Component {
   }
 
   canWithdraw() {
-    return (parseFloat(this.state.amount) > 0 && parseFloat(this.state.amount) <= parseFloat(this.state.fromBalance))
+    return (i18nParseFloat(this.state.amount) > 0 && i18nParseFloat(this.state.amount) <= parseFloat(this.state.fromBalance))
   }
 
   withdraw = async () => {
@@ -190,6 +191,7 @@ export default class SendToAddress extends React.Component {
             <Input
               width={1}
               type="number"
+              step="any"
               placeholder={currencyDisplay(0)}
               value={this.state.amount}
               onChange={event => this.updateState('amount', event.target.value)}

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 const configs = [
   {
-    DOMAINS: ["localhost", "10.0.0.107", "sundai.fritz.box", /192\.168\..*/, /.*\.ngrok\.io/],
+    DOMAINS: ["localhost", "151.217.248.171", "10.0.0.107", "sundai.fritz.box", /192\.168\..*/, /.*\.ngrok\.io/],
     PLANET_A: {
       // In seconds
       COOLDOWN: 0

--- a/src/i18n/parseFloat.js
+++ b/src/i18n/parseFloat.js
@@ -1,0 +1,12 @@
+// NOTE: This module implements a localized parseFloat function
+// that can be used to parse user input into correct floating point numbers.
+import numeral from "numeral";
+import parseDecimalNumber from "parse-decimal-number";
+import i18next from "./index";
+
+const { language } = i18next;
+// NOTE: I'm not sure if it's fine to split by the IETF language tag by -
+// to get the locale... numeral, however, only takes that, not the minus.
+const options = numeral.localeData(language.split("-")[0]).delimiters;
+
+export default parseDecimalNumber.withOptions(options);


### PR DESCRIPTION
Fixes #47 

Description:

- For user input, we want to accept `.` and `,` as valid inputs for floats
- Depending on the users "locale", we need to parse the user input